### PR TITLE
fix: Clean up CSS and improve mobile UI responsiveness

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -120,6 +120,9 @@
 
     /* Header Height */
     --header-height: 4rem;
+
+    /* Remove default focus outlines on mobile*/
+    -webkit-tap-highlight-color: transparent !important;
 }
 
 /* ==========================================
@@ -331,12 +334,12 @@ body.modern-theme::before {
 .btn-primary {
     background-color: var(--primary-600);
     color: white;
-    border-color: var(--primary-600);
+    border: 1px solid var(--primary-600);
 }
 
 .btn-primary:hover:not(:disabled) {
     background-color: var(--primary-700);
-    border-color: var(--primary-700);
+    border: 1px solid var(--primary-700);
     transform: translateY(-1px);
     box-shadow: var(--shadow-md);
 }
@@ -344,12 +347,12 @@ body.modern-theme::before {
 .btn-secondary {
     background-color: var(--secondary-100);
     color: var(--secondary-700);
-    border-color: var(--secondary-300);
+    border: 1px solid var(--secondary-300);
 }
 
 .btn-secondary:hover:not(:disabled) {
     background-color: var(--secondary-200);
-    border-color: var(--secondary-400);
+    border: 1px solid var(--secondary-400);
 }
 
 .btn-large {
@@ -368,13 +371,13 @@ body.modern-theme::before {
 .back-btn {
     background-color: var(--secondary-900);
     color: white;
-    border-color: var(--secondary-900);
+    border: 1px solid var(--secondary-900);
     border-radius: var(--radius-3xl);
 }
 
 .back-btn:hover:not(:disabled) {
     background-color: var(--primary-700);
-    border-color: var(--primary-700);
+    border: 1px solid var(--primary-700);
     transform: translateY(-1px);
     box-shadow: var(--shadow-md);
 }
@@ -382,7 +385,7 @@ body.modern-theme::before {
 .logout-btn {
     background-color: var(--secondary-900);
     color: white;
-    border-color: var(--secondary-900);
+    border: 1px solid var(--secondary-900);
     border-radius: var(--radius-3xl);
     display: flex;
     align-items: center;
@@ -392,12 +395,11 @@ body.modern-theme::before {
     font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all var(--transition-fast);
-    border: 1px solid transparent;
 }
 
 .logout-btn:hover {
     background-color: var(--primary-700);
-    border-color: var(--primary-700);
+    border: 1px solid var(--primary-700);
     transform: translateY(-1px);
     box-shadow: var(--shadow-md);
 }
@@ -660,6 +662,10 @@ body.modern-theme::before {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
+.user-dropdown-trigger:focus{
+    border: 1px solid rgba(15, 23, 42, 0.95) !important;
+}
+
 .user-dropdown-trigger .user-info {
     display: flex;
     align-items: center;
@@ -735,7 +741,6 @@ body.modern-theme::before {
     transition: all var(--transition-fast);
     z-index: 1000;
     overflow: hidden;
-    /* padding: var(--space-1); */
 }
 
 .user-dropdown.open .user-dropdown-menu {
@@ -783,34 +788,4 @@ body.modern-theme::before {
     align-items: center;
     gap: var(--space-2);
     margin-left: auto; /* Push entire actions section to right */
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-    .user-dropdown-trigger .user-details {
-        display: none;
-    }
-    
-    .user-dropdown-trigger {
-        padding: var(--space-2);
-        min-width: 40px;
-        justify-content: center;
-    }
-    
-    .user-dropdown-trigger .user-info {
-        gap: 0;
-    }
-    
-    .user-dropdown-trigger .dropdown-arrow {
-        margin-left: 0;
-        position: absolute;
-        bottom: 2px;
-        right: 2px;
-        font-size: 8px;
-    }
-    
-    .user-dropdown-menu {
-        right: -8px;
-        min-width: 160px;
-    }
 }

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -221,7 +221,6 @@
     }
     
     .rating-display > div {
-        /* padding: var(--space-4); */
         width: 100%;
         box-sizing: border-box;
     }
@@ -244,7 +243,6 @@
     }
     
     .rating-display > div {
-        /* padding: var(--space-4); */
         /* Stack internal columns on mobile */
         grid-template-columns: 1fr !important;
         gap: var(--space-4) !important;
@@ -265,6 +263,9 @@
         padding: var(--space-2) var(--space-3) !important;
         font-size: var(--font-size-xs) !important;
     }
+
+    /* User drop down changes for responsive design */
+
 }
 
 @media (max-width: 480px) {
@@ -306,6 +307,10 @@
         order: -1 !important;
         margin-right: auto !important;
         pointer-events: auto !important;
+        padding: var(--space-1) var(--space-3) !important;
+        font-size: 11px !important;
+        min-height: 36px !important;
+        border-radius: 18px !important;
     }
     
     /* Logout button - force to the right */
@@ -314,6 +319,61 @@
         order: 999 !important;
         margin-left: auto !important;
         pointer-events: auto !important;
+        padding: var(--space-1) var(--space-2) !important;
+        font-size: 11px !important;
+        min-height: 36px !important;
+        border-radius: 18px !important;
+    }
+    
+    /* User dropdown - ensure it's clickable on mobile */
+    .header-actions .user-dropdown,
+    .header-actions .user-dropdown-trigger {
+        pointer-events: auto !important;
+    }
+    
+    /* Mobile user dropdown sizing */
+    .user-dropdown-trigger {
+        padding: var(--space-1) var(--space-2) !important;
+        min-height: 36px !important;
+        border-radius: 18px !important;
+        gap: var(--space-1) !important;
+    }
+    
+    .user-dropdown-trigger .user-avatar {
+        width: 20px !important;
+        height: 20px !important;
+        font-size: 10px !important;
+    }
+    
+    .user-dropdown-trigger .user-name {
+        font-size: 11px !important;
+        max-width: 70px !important;
+        line-height: 1.1 !important;
+    }
+    
+    .user-dropdown-trigger .user-role {
+        font-size: 9px !important;
+        max-width: 50px !important;
+        line-height: 1.1 !important;
+    }
+    
+    .user-dropdown-trigger .dropdown-arrow {
+        font-size: 10px !important;
+        width: 10px !important;
+        height: 10px !important;
+    }
+    
+    .user-dropdown-menu {
+        min-width: 120px !important;
+        right: -4px !important;
+    }
+    
+    .dropdown-item,
+    .logout-item {
+        padding: var(--space-1) var(--space-2) !important;
+        font-size: 11px !important;
+        min-height: 32px !important;
+        gap: var(--space-1) !important;
     }
     
     .login-wrapper {
@@ -381,7 +441,6 @@
     .rating-group {
         flex-direction: column !important;
         align-items: flex-start !important;
-        /* gap: var(--space-3) !important; */
         padding: var(--space-3) !important;
     }
     
@@ -424,11 +483,6 @@
     .form-actions .btn {
         font-size: var(--font-size-sm) !important;
         padding: var(--space-3) var(--space-4) !important;
-    }
-    
-    .page-title {
-        font-size: var(--font-size-lg);
-        gap: var(--space-2);
     }
     
     .dashboard-header {
@@ -493,6 +547,10 @@
         font-size: var(--font-size-lg) !important;
         gap: var(--space-2) !important;
     }
+
+    .rating-container .page-title  {
+        margin-top: var(--space-5);
+    }
     
     .page-subtitle {
         font-size: var(--font-size-sm) !important;
@@ -500,7 +558,7 @@
     
     .ta-name {
         font-size: var(--font-size-xs) !important;
-        /* margin-bottom: var(--space-3) !important; */
+        margin-bottom: var(--space-3);
     }
     
     .period-badge {
@@ -515,18 +573,6 @@
         padding: 0 var(--space-2);
         text-align: center;
         width: 100%;
-    }
-    
-    .page-title {
-        font-size: var(--font-size-lg);
-        gap: var(--space-2);
-        /* margin-bottom: var(--space-2); */
-    }
-    
-    .ta-name {
-        font-size: var(--font-size-xs);
-        margin-bottom: var(--space-3);
-        /* margin-top: var(--space-1); */
     }
     
     .period-badge {
@@ -781,139 +827,9 @@
         padding: var(--space-2) var(--space-3);
         font-size: var(--font-size-sm);
     }
-    
-    /* Additional user dropdown adjustments for smaller screens */
-    .dashboard-screen .dashboard-header .header-actions {
-        top: var(--space-4) !important;
-        right: var(--space-4) !important;
-    }
-    
-    /* Override base.css mobile styles - force our layout */
-    .user-dropdown-trigger {
-        padding: var(--space-1) !important;
-        min-height: 32px !important;
-        border-radius: 16px !important;
-        justify-content: space-between !important; /* Space between user-info and arrow */
-        min-width: auto !important;
-        gap: 3px !important;
-        display: flex !important;
-        align-items: center !important;
-        position: relative !important;
-        cursor: pointer !important;
-        pointer-events: auto !important;
-    }
-    
-    /* Force user details to stay visible - override base.css hiding */
-    .user-dropdown-trigger .user-details {
-        display: flex !important;
-        flex-direction: column !important;
-    }
-    
-    .user-dropdown-trigger .user-info {
-        gap: 2px !important;
-        display: flex !important;
-        align-items: center !important;
-        flex: 1 !important; /* Take available space */
-        position: relative !important;
-    }
-    
-    .user-dropdown-trigger .user-avatar {
-        width: 18px !important;
-        height: 18px !important;
-        font-size: 8px !important;
-    }
-    
-    .user-dropdown-trigger .user-name {
-        font-size: 8px !important;
-        max-width: 45px !important;
-        line-height: 1.1 !important;
-    }
-    
-    .user-dropdown-trigger .user-role {
-        font-size: 7px !important;
-        max-width: 45px !important;
-        line-height: 1.1 !important;
-    }
-    
-    /* Override base.css arrow positioning */
-    .user-dropdown-trigger .dropdown-arrow {
-        font-size: 10px !important;
-        margin-left: 0 !important;
-        flex-shrink: 0 !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        width: 12px !important;
-        height: 12px !important;
-        position: static !important; /* Override absolute positioning from base.css */
-        bottom: auto !important;
-        right: auto !important;
-    }
-    
-    /* Ensure dropdown functionality works */
-    .user-dropdown {
-        position: relative !important;
-        z-index: 1001 !important;
-    }
-    
-    .user-dropdown-menu {
-        position: absolute !important;
-        z-index: 1002 !important;
-        pointer-events: auto !important;
-        right: 0 !important; /* Override base.css right: -8px */
-        min-width: 120px !important;
-        top: calc(100% + 2px) !important;
-        background: var(--secondary-900) !important;
-        border: 1px solid var(--secondary-800) !important;
-        border-radius: 12px !important;
-        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3) !important;
-        opacity: 0 !important;
-        visibility: hidden !important;
-        transform: translateY(-10px) !important;
-        transition: all var(--transition-fast) !important;
-        overflow: hidden !important;
-        padding: var(--space-1) !important;
-    }
-    
-    /* Ensure dropdown shows when open */
-    .user-dropdown.open .user-dropdown-menu {
-        opacity: 1 !important;
-        visibility: visible !important;
-        transform: translateY(0) !important;
-    }
-    
-    /* Style dropdown items for mobile */
-    .user-dropdown-menu .dropdown-item,
-    .user-dropdown-menu .logout-item {
-        display: flex !important;
-        align-items: center !important;
-        gap: var(--space-1) !important;
-        width: 100% !important;
-        padding: var(--space-2) var(--space-3) !important;
-        background: transparent !important;
-        border: none !important;
-        font-size: var(--font-size-xs) !important;
-        font-weight: var(--font-weight-medium) !important;
-        text-align: left !important;
-        cursor: pointer !important;
-        transition: all 0.15s ease !important;
-        border-radius: 8px !important;
-        min-height: 32px !important;
-        color: white !important;
-        box-sizing: border-box !important;
-    }
-    
-    .user-dropdown-menu .dropdown-item:hover,
-    .user-dropdown-menu .logout-item:hover {
-        background: var(--secondary-800) !important;
-        color: white !important;
-    }
 }
 
 @media (max-width: 320px) {
-    /* Don't hide user-details completely - keep the layout but make it ultra compact */
-    /* .user-details { display: none; } - Commented out to maintain desktop layout */
-    
     /* Header actions - ensure consistent positioning for ultra small screens */
     .header-actions {
         position: fixed !important;
@@ -934,9 +850,10 @@
         order: -1 !important;
         margin-right: auto !important;
         pointer-events: auto !important;
-        padding: var(--space-1) var(--space-2) !important;
-        font-size: var(--font-size-xs) !important;
+        padding: 2px 6px !important;
+        font-size: 9px !important;
         min-height: 28px !important;
+        border-radius: 14px !important;
     }
     
     /* Logout button - force to the right */
@@ -945,9 +862,16 @@
         order: 999 !important;
         margin-left: auto !important;
         pointer-events: auto !important;
-        padding: var(--space-1) var(--space-2) !important;
-        font-size: var(--font-size-xs) !important;
+        padding: 2px 6px !important;
+        font-size: 9px !important;
         min-height: 28px !important;
+        border-radius: 14px !important;
+    }
+    
+    /* User dropdown - ensure it's clickable on mobile */
+    .header-actions .user-dropdown,
+    .header-actions .user-dropdown-trigger {
+        pointer-events: auto !important;
     }
     
     /* Ultra compact user dropdown for very small screens */
@@ -956,137 +880,49 @@
         right: var(--space-2) !important;
     }
     
-    /* Override base.css mobile styles for ultra small screens */
+    /* Ultra small screen specific overrides */
     .user-dropdown-trigger {
-        padding: 2px 4px !important;
-        min-height: 26px !important;
-        border-radius: 13px !important;
-        justify-content: space-between !important; /* Space between user-info and arrow */
-        min-width: auto !important;
+        padding: 2px 6px !important;
+        min-height: 28px !important;
+        border-radius: 14px !important;
         gap: 2px !important;
-        display: flex !important;
-        align-items: center !important;
-        position: relative !important;
-        cursor: pointer !important;
-        pointer-events: auto !important;
-    }
-    
-    /* Force user details to stay visible even on very small screens - override base.css */
-    .user-dropdown-trigger .user-details {
-        display: flex !important;
-        flex-direction: column !important;
-    }
-    
-    .user-dropdown-trigger .user-info {
-        gap: 1px !important;
-        display: flex !important;
-        align-items: center !important;
-        flex: 1 !important; /* Take available space */
-        position: relative !important;
     }
     
     .user-dropdown-trigger .user-avatar {
-        width: 14px !important;
-        height: 14px !important;
-        font-size: 6px !important;
+        width: 16px !important;
+        height: 16px !important;
+        font-size: 8px !important;
     }
     
     .user-dropdown-trigger .user-name {
-        font-size: 7px !important;
-        max-width: 30px !important;
+        font-size: 9px !important;
+        max-width: 40px !important;
         line-height: 1 !important;
     }
     
     .user-dropdown-trigger .user-role {
-        font-size: 6px !important;
-        max-width: 30px !important;
+        font-size: 7px !important;
+        max-width: 40px !important;
         line-height: 1 !important;
     }
     
-    /* Override base.css arrow positioning for ultra small screens */
     .user-dropdown-trigger .dropdown-arrow {
         font-size: 8px !important;
-        margin-left: 0 !important;
-        flex-shrink: 0 !important;
-        display: flex !important;
-        align-items: center !important;
-        justify-content: center !important;
-        width: 10px !important;
-        height: 10px !important;
-        position: static !important; /* Override absolute positioning from base.css */
-        bottom: auto !important;
-        right: auto !important;
+        width: 8px !important;
+        height: 8px !important;
     }
     
     .user-dropdown-menu {
-        min-width: 100px !important;
-        border-radius: 12px !important;
-        right: 0 !important; /* Override base.css right: -8px */
-        top: calc(100% + 2px) !important;
-        background: var(--secondary-900) !important;
-        border: 1px solid var(--secondary-800) !important;
-        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3) !important;
-        opacity: 0 !important;
-        visibility: hidden !important;
-        transform: translateY(-10px) !important;
-        transition: all var(--transition-fast) !important;
-        overflow: hidden !important;
-        padding: var(--space-1) !important;
-        position: absolute !important;
-        z-index: 1003 !important;
-        pointer-events: auto !important;
-    }
-    
-    /* Ensure dropdown shows when open on ultra small screens */
-    .user-dropdown.open .user-dropdown-menu {
-        opacity: 1 !important;
-        visibility: visible !important;
-        transform: translateY(0) !important;
+        min-width: 80px !important;
+        right: -4px !important;
     }
     
     .dropdown-item,
     .logout-item {
-        display: flex !important;
-        align-items: center !important;
-        gap: 4px !important;
-        width: 100% !important;
-        padding: var(--space-2) var(--space-1) !important;
-        background: transparent !important;
-        border: none !important;
-        font-size: 10px !important;
-        font-weight: var(--font-weight-medium) !important;
-        text-align: left !important;
-        cursor: pointer !important;
-        transition: all 0.15s ease !important;
-        border-radius: 8px !important;
-        min-height: 28px !important;
-        color: white !important;
-        box-sizing: border-box !important;
-    }
-    
-    .dropdown-item:hover,
-    .logout-item:hover {
-        background: var(--secondary-800) !important;
-        color: white !important;
-    }
-    
-    /* Ensure dropdown is clickable on mobile */
-    .user-dropdown {
-        position: relative !important;
-        z-index: 1001 !important;
-    }
-    
-    .user-dropdown-trigger {
-        position: relative !important;
-        z-index: 1002 !important;
-        cursor: pointer !important;
-        pointer-events: auto !important;
-    }
-    
-    .user-dropdown-menu {
-        position: absolute !important;
-        z-index: 1003 !important;
-        pointer-events: auto !important;
+        padding: var(--space-1) 6px !important;
+        font-size: 8px !important;
+        min-height: 24px !important;
+        gap: 2px !important;
     }
     
     .dashboard-container,
@@ -1097,7 +933,6 @@
     .rating-group {
         flex-direction: column;
         align-items: flex-start;
-        /* gap: var(--space-4); */
     }
     
     .star-rating {
@@ -1121,7 +956,6 @@
     }
     
     .rating-display > div > div[style*="margin-bottom: 15px"] {
-        /* padding: var(--space-2) !important; */
         margin-bottom: var(--space-2) !important;
     }
     
@@ -1291,135 +1125,3 @@
 .p-4 { padding: var(--space-4); }
 .p-6 { padding: var(--space-6); }
 .p-8 { padding: var(--space-8); }
-
-/* ==========================================
-   Header Actions Responsive Design
-   ========================================== */
-
-@media (max-width: 768px) {
-    /* Header actions container - full width to contain both buttons */
-    .header-actions {
-        position: fixed !important;
-        top: var(--space-3) !important;
-        left: var(--space-3) !important;
-        right: var(--space-3) !important;
-        z-index: 1000 !important;
-        display: flex !important;
-        justify-content: space-between !important;
-        align-items: center !important;
-        width: auto !important;
-        pointer-events: none !important; /* Allow clicks to pass through container */
-    }
-    
-    /* Enable pointer events for buttons */
-    .header-actions .btn {
-        pointer-events: auto !important;
-        padding: var(--space-2) var(--space-3) !important;
-        font-size: var(--font-size-xs) !important;
-        min-height: 40px !important;
-        display: flex !important;
-        align-items: center !important;
-        gap: var(--space-1) !important;
-    }
-    
-    /* Back button - force to the left */
-    .header-actions .back-btn {
-        position: static !important;
-        order: -1 !important; /* Force to appear first */
-        margin-right: auto !important; /* Push everything else to the right */
-        left: auto !important;
-        right: auto !important;
-        top: auto !important;
-    }
-    
-    /* Logout button - always on the right */
-    .header-actions .logout-btn {
-        position: static !important;
-        order: 999 !important; /* Force to appear last */
-        margin-left: auto !important; /* Push to the right */
-        left: auto !important;
-        right: auto !important;
-        top: auto !important;
-    }
-    
-    /* Hide button text labels on very small screens, keep icons */
-    .header-actions .btn span {
-        display: none;
-    }
-    
-    /* For dashboard screen (TA selection) - move logout button out of header */
-    .dashboard-screen #logoutButton {
-        /* position: fixed !important; */
-        top: var(--space-3) !important;
-        right: var(--space-3) !important;
-        z-index: 1000 !important;
-        padding: var(--space-1) var(--space-2) !important;
-        font-size: var(--font-size-xs) !important;
-        min-height: 0 !important;
-        display: flex !important;
-        align-items: center !important;
-        gap: var(--space-1) !important;
-        pointer-events: auto !important;
-    }
-    
-    /* Allow header-actions to be visible on dashboard screen */
-    .dashboard-screen .dashboard-header .header-actions {
-        position: fixed !important;
-        top: var(--space-6) !important;
-        right: var(--space-6) !important;
-        z-index: 1000 !important;
-        visibility: visible !important;
-        height: auto !important;
-        overflow: visible !important;
-    }
-    
-    /* Mobile adjustments for user dropdown - keep desktop layout but adjust sizes */
-    .user-dropdown-trigger {
-        padding: var(--space-1) var(--space-2) !important;
-        min-height: 36px !important;
-        font-size: var(--font-size-xs) !important;
-        border-radius: 18px !important; /* Maintain proportional border radius */
-        justify-content: flex-start !important; /* Override base.css centering */
-        min-width: auto !important; /* Override base.css min-width */
-    }
-    
-    /* Keep user details visible on mobile - override base.css hiding */
-    .user-dropdown-trigger .user-details {
-        display: flex !important; /* Override display: none from base.css */
-    }
-    
-    .user-dropdown-trigger .user-info {
-        gap: var(--space-1) !important; /* Override gap: 0 from base.css */
-    }
-    
-    .user-dropdown-trigger .user-avatar {
-        width: 24px !important;
-        height: 24px !important;
-        font-size: var(--font-size-xs) !important;
-    }
-    
-    .user-dropdown-trigger .user-name {
-        font-size: var(--font-size-xs) !important;
-        max-width: 80px !important;
-    }
-    
-    .user-dropdown-trigger .user-role {
-        font-size: 10px !important;
-        max-width: 80px !important;
-    }
-    
-    .user-dropdown-trigger .dropdown-arrow {
-        font-size: 10px !important;
-        margin-left: var(--space-1) !important; /* Restore proper margin */
-    }
-    
-    .user-dropdown-menu {
-        min-width: 120px !important;
-    }
-    
-    .dropdown-item {
-        padding: var(--space-1) var(--space-2) !important;
-        font-size: var(--font-size-xs) !important;
-        min-height: 32px !important;
-    }
-}


### PR DESCRIPTION
- Remove redundant CSS comments and unused code from responsive.css
- Fix border property inconsistencies in base.css (use full border syntax)
- Add comprehensive mobile user dropdown sizing across breakpoints
- Implement mobile-friendly header actions layout with proper pointer-events
- Add webkit tap highlight removal for better mobile UX
- Standardize user dropdown focus states and remove unwanted outlines
- Optimize responsive breakpoints for 480px and 320px screens
- Clean up unused responsive styles and consolidate duplicate rules